### PR TITLE
feat: Implement basic MCP server using FastMCP for Issue #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,9 @@ planning_agent/
 │   ├── requirement_analyzer.py # 要件分析エージェント
 │   ├── task_decomposer.py     # タスク分解エージェント
 │   └── issue_manager.py       # 課題管理エージェント
-├── mcp/
+├── mcp_interface/           # MCPサーバー関連
 │   ├── __init__.py
-│   ├── interface.py           # MCPインターフェース
-│   └── handlers.py            # MCP機能ハンドラー
+│   └── server.py            # MCPサーバー実装 (FastMCP使用)
 ├── utils/
 │   ├── __init__.py
 │   ├── file_manager.py        # ファイル入出力機能

--- a/docs/design_doc.md
+++ b/docs/design_doc.md
@@ -81,10 +81,9 @@ planning_agent/
 │   ├── requirement_analyzer.py # 要件分析エージェント
 │   ├── task_decomposer.py     # タスク分解エージェント
 │   └── issue_manager.py       # 課題管理エージェント
-├── mcp/
+├── mcp_interface/           # MCPサーバー関連
 │   ├── __init__.py
-│   ├── interface.py           # MCPインターフェース
-│   └── handlers.py            # MCP機能ハンドラー
+│   └── server.py            # MCPサーバー実装 (FastMCP使用)
 ├── utils/
 │   ├── __init__.py
 │   ├── file_manager.py        # ファイル入出力機能
@@ -243,14 +242,6 @@ issues:
   - `analyze_issue(issue_description, plan)`: 問題分析
   - `generate_action_plan(issue, plan)`: 対応策の生成
   - `track_issue(issue_id, status)`: 課題ステータス管理
-
-### MCPInterface
-- **責任**: MCPプロトコル処理、エージェントとの連携
-- **主要メソッド**:
-  - `handle_create_plan(request)`: CreatePlan処理
-  - `handle_update_plan(request)`: UpdatePlan処理
-  - `handle_report_issue(request)`: ReportIssue処理
-  - `handle_reset_plan(request)`: ResetPlan処理
 
 ### FileManager
 - **責任**: YAML形式のファイル操作、履歴管理

--- a/mcp_interface/server.py
+++ b/mcp_interface/server.py
@@ -1,0 +1,168 @@
+"""
+MCPサーバー実装
+
+このモジュールは、FastMCPライブラリを使用してPlanning AgentシステムのMCPサーバーを実装します。
+クライアントからのリクエストを受け付け、適切なツール関数を呼び出します。
+"""
+
+import logging
+from typing import Dict, Any, List, Optional
+
+# FastMCPのインポート
+from mcp.server.fastmcp import FastMCP
+
+# ロガーの設定
+logger = logging.getLogger(__name__)
+
+# ファイル管理ユーティリティのインポート
+from utils.file_manager import FileManager
+
+# ファイルマネージャのインスタンス
+file_manager = FileManager()
+
+
+# FastMCPサーバーインスタンスの作成
+mcp_server = FastMCP("planning_agent")
+
+
+@mcp_server.tool()
+def create_plan(task_description: str, 
+                constraints: Optional[List[str]] = None, 
+                task_id: Optional[str] = None,
+                title: Optional[str] = None) -> Dict[str, Any]:
+    """
+    新しいタスクからプランを作成します。
+
+    Args:
+        task_description: タスクの説明
+        constraints: タスクの制約条件リスト
+        task_id: (オプション) 指定されたタスクID
+        title: (オプション) タスクのタイトル
+
+    Returns:
+        プランID、初期プラン、または必要な場合は質問を含む辞書
+    """
+    logger.info(f"create_planが呼び出されました: task_description='{task_description[:50]}...'", )
+    
+    # TODO: PlanningManagerAgentを呼び出してプラン作成を依頼する
+    pass 
+    
+    # 現時点ではダミーのレスポンスを返す
+    # 将来的にはエージェントからの結果を返す
+    dummy_plan_id = f"plan-{task_id or 'new'}"
+    return {
+        "status": "pending", 
+        "message": "プラン作成を開始しました", 
+        "plan_id": dummy_plan_id,
+        "task_id": task_id or "generated_task_id" 
+    }
+
+
+@mcp_server.tool()
+def update_plan(plan_id: str, updates: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    既存のプランを更新します。
+
+    Args:
+        plan_id: 更新するプランのID
+        updates: 更新内容（完了タスク、変更内容など）を含む辞書
+
+    Returns:
+        更新されたプラン情報を含む辞書
+    """
+    logger.info(f"update_planが呼び出されました: plan_id='{plan_id}'")
+    
+    # TODO: PlanningManagerAgentを呼び出してプラン更新を依頼する
+    pass
+    
+    # 現時点ではダミーのレスポンスを返す
+    return {
+        "status": "pending", 
+        "message": "プラン更新を開始しました", 
+        "plan_id": plan_id
+    }
+
+
+@mcp_server.tool()
+def report_issue(plan_id: str, description: str, 
+                 impact: Optional[str] = None, 
+                 suggested_actions: Optional[List[str]] = None,
+                 related_subtasks: Optional[List[str]] = None) -> Dict[str, Any]:
+    """
+    プラン実行中の問題を報告し、対応方針を取得します。
+
+    Args:
+        plan_id: 問題が発生したプランのID
+        description: 問題の説明
+        impact: (オプション) 問題の影響
+        suggested_actions: (オプション) 推奨される対応策
+        related_subtasks: (オプション) 関連するサブタスクIDのリスト
+
+    Returns:
+        問題の分析結果や推奨される対応策を含む辞書
+    """
+    logger.info(f"report_issueが呼び出されました: plan_id='{plan_id}', description='{description[:50]}...'", )
+    
+    # TODO: PlanningManagerAgentを呼び出して課題分析と対応策生成を依頼する
+    pass
+    
+    # 現時点ではダミーのレスポンスを返す
+    return {
+        "status": "pending", 
+        "message": "課題報告を受け付けました", 
+        "plan_id": plan_id,
+        "suggested_next_steps": ["課題を分析しています..."]
+    }
+
+
+@mcp_server.tool()
+def reset_plan(plan_id: str, backup: bool = True) -> Dict[str, Any]:
+    """
+    タスク完了またはリセット要求により、プラン関連データをクリーンアップします。
+
+    Args:
+        plan_id: リセットするプランのID
+        backup: (オプション) 削除前にプラン履歴をバックアップするかどうか (デフォルト: True)
+
+    Returns:
+        リセット処理の結果を含む辞書
+    """
+    logger.info(f"reset_planが呼び出されました: plan_id='{plan_id}', backup={backup}")
+    
+    # TODO: PlanningManagerAgentを呼び出してリセット処理を依頼する
+    # (FileManagerを使ったファイル削除など)
+    pass
+    
+    # 現時点ではダミーのレスポンスを返す
+    try:
+        if backup:
+            # ダミーでバックアップ処理をシミュレート
+            backup_path = f"/path/to/history/{plan_id}/backup.yaml"
+            logger.info(f"プランをバックアップしました (ダミー): {backup_path}")
+        else:
+            backup_path = None
+            
+        # ダミーで削除処理をシミュレート
+        logger.info(f"プランを削除しました (ダミー): {plan_id}")
+        
+        return {
+            "status": "success", 
+            "message": "プランのリセットが完了しました", 
+            "plan_id": plan_id,
+            "backup_path": backup_path
+        }
+    except Exception as e:
+        logger.error(f"プランのリセット中にエラーが発生しました (ダミー): {e}")
+        return {
+            "status": "error",
+            "message": f"プランのリセット中にエラーが発生しました: {e}",
+            "plan_id": plan_id
+        }
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    logger.info("Planning Agent MCPサーバーを起動します...")
+    # stdioトランスポートを使用してサーバーを起動
+    # クライアント（例: Claude Desktop, IDE）はこのプロセスと標準入出力で通信します
+    mcp_server.run(transport='stdio') 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ dependencies = [
     "smolagents==0.1.0",
     "pyyaml>=6.0.1,<7.0.0",
     "transformers==4.38.2",
+    "fastmcp>=0.4.1",
+    "mcp>=1.6.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/mcp_interface/test_server.py
+++ b/tests/mcp_interface/test_server.py
@@ -1,0 +1,84 @@
+"""
+mcp_interface/server.py のユニットテスト
+"""
+
+import pytest
+from typing import Dict, Any
+
+# テスト対象の関数をインポート
+from mcp_interface.server import create_plan, update_plan, report_issue, reset_plan
+
+# モック用のFileManager (実際のファイル操作を防ぐ)
+class MockFileManager:
+    def save_requirements(self, task_id: str, requirements: Dict[str, Any]) -> str:
+        return f"mock_requirements/{task_id}.yaml"
+
+    def save_plan(self, plan_id: str, plan: Dict[str, Any]) -> tuple[str, int]:
+        return f"mock_plans/{plan_id}.yaml", 1
+
+    def load_plan(self, plan_id: str) -> Dict[str, Any]:
+        if plan_id == "existing_plan":
+            return {"plan_id": plan_id, "task_id": "task-123", "version": 1, "subtasks": []}
+        raise FileNotFoundError(f"プランが見つかりません: {plan_id}")
+
+    def backup_plan(self, plan_id: str) -> str:
+        return f"mock_history/{plan_id}/v1_backup.yaml"
+
+    def save_issue(self, task_id: str, issue: Dict[str, Any]) -> str:
+        return f"mock_issues/{task_id}.yaml"
+    
+    def delete_plan(self, plan_id: str) -> bool:
+        return True
+
+# テスト内でFileManagerをモックに置き換える
+@pytest.fixture(autouse=True)
+def mock_file_manager(monkeypatch):
+    mock_instance = MockFileManager()
+    # mcp_interface.server モジュール内の file_manager をモックに差し替える
+    monkeypatch.setattr("mcp_interface.server.file_manager", mock_instance)
+
+def test_create_plan():
+    """create_plan 関数の基本的なテスト"""
+    result = create_plan(task_description="テストタスクの説明")
+    assert isinstance(result, dict)
+    assert "status" in result
+    assert "plan_id" in result
+    assert "task_id" in result
+    assert result["status"] == "pending" # ダミー実装の確認
+
+def test_update_plan():
+    """update_plan 関数の基本的なテスト"""
+    result = update_plan(plan_id="existing_plan", updates={"status": "in_progress"})
+    assert isinstance(result, dict)
+    assert "status" in result
+    assert "plan_id" in result
+    assert result["status"] == "pending" # ダミー実装の確認
+
+def test_report_issue():
+    """report_issue 関数の基本的なテスト"""
+    result = report_issue(plan_id="existing_plan", description="問題が発生しました")
+    assert isinstance(result, dict)
+    assert "status" in result
+    assert "plan_id" in result
+    assert "suggested_next_steps" in result
+    assert result["status"] == "pending" # ダミー実装の確認
+
+def test_reset_plan_with_backup():
+    """reset_plan 関数の基本的なテスト (バックアップあり)"""
+    result = reset_plan(plan_id="existing_plan", backup=True)
+    assert isinstance(result, dict)
+    assert "status" in result
+    assert "plan_id" in result
+    assert "backup_path" in result
+    assert result["status"] == "success" # ダミー実装の確認
+    assert result["backup_path"] is not None
+
+def test_reset_plan_without_backup():
+    """reset_plan 関数の基本的なテスト (バックアップなし)"""
+    result = reset_plan(plan_id="existing_plan", backup=False)
+    assert isinstance(result, dict)
+    assert "status" in result
+    assert "plan_id" in result
+    assert "backup_path" in result
+    assert result["status"] == "success" # ダミー実装の確認
+    assert result["backup_path"] is None

--- a/uv.lock
+++ b/uv.lock
@@ -520,6 +520,23 @@ wheels = [
 ]
 
 [[package]]
+name = "fastmcp"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "mcp" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "python-dotenv" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6f/84/17b549133263d7ee77141970769bbc401525526bf1af043ea6842bce1a55/fastmcp-0.4.1.tar.gz", hash = "sha256:713ad3b8e4e04841c9e2f3ca022b053adb89a286ceffad0d69ae7b56f31cbe64", size = 785575 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/0b/008a340435fe8f0879e9d608f48af2737ad48440e09bd33b83b3fd03798b/fastmcp-0.4.1-py3-none-any.whl", hash = "sha256:664b42c376fb89ec90a50c9433f5a1f4d24f36696d6c41b024b427ae545f9619", size = 35282 },
+]
+
+[[package]]
 name = "ffmpy"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -716,6 +733,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517 },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/60/8f4281fa9bbf3c8034fd54c0e7412e66edbab6bc74c4996bd616f8d0406e/httpx-sse-0.4.0.tar.gz", hash = "sha256:1e81a3a3070ce322add1d3529ed42eb5f70817f45ed6ec915ab753f961139721", size = 12624 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/9b/a181f281f65d776426002f330c31849b86b31fc9d848db62e16f03ff739f/httpx_sse-0.4.0-py3-none-any.whl", hash = "sha256:f329af6eae57eaa2bdfd962b42524764af68075ea87370a2de920af5341e318f", size = 7819 },
 ]
 
 [[package]]
@@ -1067,6 +1093,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/80/0985960e4b89922cb5a0bac0ed39c5b96cbc1a536a99f30e8c220a996ed9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9", size = 24098 },
     { url = "https://files.pythonhosted.org/packages/82/78/fedb03c7d5380df2427038ec8d973587e90561b2d90cd472ce9254cf348b/MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6", size = 15208 },
     { url = "https://files.pythonhosted.org/packages/4f/65/6079a46068dfceaeabb5dcad6d674f5f5c61a6fa5673746f42a9f4c233b3/MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f", size = 15739 },
+]
+
+[[package]]
+name = "mcp"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "uvicorn" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/d2/f587cb965a56e992634bebc8611c5b579af912b74e04eb9164bd49527d21/mcp-1.6.0.tar.gz", hash = "sha256:d9324876de2c5637369f43161cd71eebfd803df5a95e46225cab8d280e366723", size = 200031 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/30/20a7f33b0b884a9d14dd3aa94ff1ac9da1479fe2ad66dd9e2736075d2506/mcp-1.6.0-py3-none-any.whl", hash = "sha256:7bd24c6ea042dbec44c754f100984d186620d8b841ec30f1b19eda9b93a634d0", size = 76077 },
 ]
 
 [[package]]
@@ -1629,6 +1674,8 @@ name = "planning-agent"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "fastmcp" },
+    { name = "mcp" },
     { name = "pyyaml" },
     { name = "smolagents" },
     { name = "transformers" },
@@ -1654,7 +1701,9 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.7.0,<24.0.0" },
+    { name = "fastmcp", specifier = ">=0.4.1" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0,<6.0.0" },
+    { name = "mcp", specifier = ">=1.6.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.5.1,<2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.0,<9.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0,<5.0.0" },
@@ -1908,6 +1957,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/cd/c59707e35a47ba4cbbf153c3f7c56420c58653b5801b055dc52cccc8e2dc/pydantic_core-2.33.1-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:52928d8c1b6bda03cc6d811e8923dffc87a2d3c8b3bfd2ce16471c7147a24850", size = 2250175 },
     { url = "https://files.pythonhosted.org/packages/84/32/e4325a6676b0bed32d5b084566ec86ed7fd1e9bcbfc49c578b1755bde920/pydantic_core-2.33.1-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:1b30d92c9412beb5ac6b10a3eb7ef92ccb14e3f2a8d7732e2d739f58b3aa7544", size = 2254674 },
     { url = "https://files.pythonhosted.org/packages/12/6f/5596dc418f2e292ffc661d21931ab34591952e2843e7168ea5a52591f6ff/pydantic_core-2.33.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:f995719707e0e29f0f41a8aa3bcea6e761a36c9136104d3189eafb83f5cec5e5", size = 2080951 },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.8.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/82/c79424d7d8c29b994fb01d277da57b0a9b09cc03c3ff875f9bd8a86b2145/pydantic_settings-2.8.1.tar.gz", hash = "sha256:d5c663dfbe9db9d5e1c646b2e161da12f0d734d422ee56f567d0ea2cee4e8585", size = 83550 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/53/a64f03044927dc47aafe029c42a5b7aabc38dfb813475e0e1bf71c4a59d0/pydantic_settings-2.8.1-py3-none-any.whl", hash = "sha256:81942d5ac3d905f7f3ee1a70df5dfb62d5569c12f51a5a647defc1c3d9ee2e9c", size = 30839 },
 ]
 
 [[package]]
@@ -2502,6 +2564,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072 },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/a4/80d2a11af59fe75b48230846989e93979c892d3a20016b42bb44edb9e398/sse_starlette-2.2.1.tar.gz", hash = "sha256:54470d5f19274aeed6b2d473430b08b4b379ea851d953b11d7f1c4a2c118b419", size = 17376 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/e0/5b8bd393f27f4a62461c5cf2479c75a2cc2ffa330976f9f00f5f6e4f50eb/sse_starlette-2.2.1-py3-none-any.whl", hash = "sha256:6410a3d3ba0c89e7675d4c273a301d64649c03a5ef1ca101f10b47f895fd0e99", size = 10120 },
 ]
 
 [[package]]


### PR DESCRIPTION
```markdown
Closes #5

## 概要

Issue #5 に基づき、Planning Agent システムの基本的な MCP (Model Context Protocol) サーバーインターフェースを実装しました。これにより、外部クライアント（例: Claude Desktop）が標準化されたプロトコルを通じて Planning Agent の機能を利用できるようになります。

## 実装アプローチ

- `mcp` ライブラリの `FastMCP` を使用して MCP サーバー (`mcp_interface/server.py`) を実装しました。これは `docs/mcp_protocol.md` で推奨されているアプローチです。
- 設計ドキュメント (`docs/design_doc.md`) で定義された主要な MCP 機能 (`create_plan`, `update_plan`, `report_issue`, `reset_plan`) に対応するツール関数を `@mcp_server.tool()` デコレータを使用して定義しました。
- 各ツール関数の内部ロジックは現時点ではスタブ（`pass` とダミーレスポンス）となっており、将来的に対応するエージェント（PlanningManagerAgent など）を呼び出す処理を実装します。
- プロジェクト内のディレクトリ名 `mcp` が、インストールされた `mcp` ライブラリと競合する可能性があったため、ローカルディレクトリ名を `mcp_interface` に変更しました。関連するドキュメント (`README.md`, `docs/design_doc.md`) も更新しました。

## レビュアーへの注意点

- 現在の実装は MCP サーバーの骨組みであり、各ツール関数の具体的な処理ロジックは含まれていません。今後の Issue で各エージェントとの連携部分を実装します。
- `FastMCP` の利用方法やディレクトリ構造の変更が適切かご確認ください。

## テスト

- `tests/mcp_interface/test_server.py` に基本的なユニットテストを追加しました。
- 各ツール関数が呼び出され、期待される構造のレスポンス（ダミー）を返すことを確認しています。
- `FileManager` はモック化してテストを実行しました。
- `uv run pytest tests/mcp_interface/test_server.py` でテストを実行し、すべてのテストがパスすることを確認しました。カバレッジは、まだエージェントが実装されていないため、現時点では測定していません。

```