### PR TITLE
feat: Add guidance for update_plan/report_issue usage (Issue #42)

### DIFF
--- a/mcp_interface/server.py
+++ b/mcp_interface/server.py
@@ -82,7 +82,9 @@ def create_plan(task_description: str) -> str:
 """
         result_text = agent.run(prompt)
         logger.info(f"Agent run result for create_plan: {result_text}")
-        return result_text
+        # 次のアクションを促す定型文を追加
+        guidance = "\\n\\n---\\n**次のステップ:** サブタスク完了後は `update_plan` で完了報告をしてください。サブタスク実行中に問題が発生した場合は、必ず `report_issue` で報告してください。"
+        return result_text + guidance
     except Exception as e:
         logger.error(f"create_plan 処理中にエラー: {e}", exc_info=True)
         return f"[エラー] プラン作成中に予期せぬエラーが発生しました: {e}"
@@ -125,7 +127,9 @@ def update_plan(task_number: int, artifacts: List[str], comments: str) -> str:
 """
         result_text = agent.run(prompt)
         logger.info(f"Agent run result for update_plan: {result_text}")
-        return result_text
+        # 次のアクションを促す定型文を追加
+        guidance = "\\n\\n---\\n**次のステップ:** サブタスク完了後は `update_plan` で完了報告をしてください。サブタスク実行中に問題が発生した場合は、必ず `report_issue` で報告してください。"
+        return result_text + guidance
     except Exception as e:
         logger.error(f"update_plan 処理中にエラー: {e}", exc_info=True)
         return f"[エラー] プラン更新中に予期せぬエラーが発生しました: {e}"


### PR DESCRIPTION
## 変更内容の要約

`create_plan` と `update_plan` MCPツールの応答メッセージの末尾に、次のアクションとして `update_plan` または `report_issue` の利用を促す標準的な文言を追加しました。

## 実装したアプローチの詳細

`mcp_interface/server.py` 内の `create_plan` および `update_plan` 関数において、`agent.run()` によって返される結果文字列 (`result_text`) に、改行と区切り線を含む定型のガイダンス文字列を結合するように修正しました。

```python
guidance = "\n\n---\n**次のステップ:** サブタスク完了後は `update_plan` で完了報告をしてください。サブタスク実行中に問題が発生した場合は、必ず `report_issue` で報告してください。"
return result_text + guidance
```

## レビュアーへの注意点

-   追加された文言が、クライアント側（例: MCPを利用するスクリプトやUI）での表示や応答のパース処理に意図しない影響を与えないかご確認ください。
-   特に、将来的に応答形式がJSONなどに変更された場合、この文字列結合方法が適切でなくなる可能性がある点にご留意ください。（現状の応答はプレーンテキストを想定しています）

## テスト

-   ローカルでの具体的なツール呼び出しによる動作確認は行っていません。
-   コードレビューベースでの確認をお願いします。
-   コードカバレッジ情報は現時点ではありません。

Closes #42
